### PR TITLE
Improve portfolio design with hero and dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 <body>
     <header>
         <h1>Miyamo's Portfolio</h1>
+        <button id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
         <nav>
             <ul>
                 <li><a href="#about">About</a></li>
@@ -21,6 +22,9 @@
             </ul>
         </nav>
     </header>
+    <section id="hero" class="hero">
+        <p class="hero-tagline">Explore VR, AR and math driven creations.</p>
+    </section>
     <div class="ai-disclaimer">
         <p><strong>【お知らせ】</strong>このポートフォリオサイトは、AI (GitHub Copilot) との協力のもと作成されました。情報が完全に正確でない場合や、表現に不自然な点がある可能性もございます。ご理解いただけますと幸いです。</p>
     </div>
@@ -189,5 +193,11 @@
     <footer>
         <p>&copy; 2025 miyamo</p>
     </footer>
+    <script>
+        const btn = document.getElementById('theme-toggle');
+        btn.addEventListener('click', () => {
+            document.body.classList.toggle('dark');
+        });
+    </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -48,6 +48,7 @@ header {
     text-align: center;
     margin-bottom: 2rem;
     letter-spacing: 0.05em;
+    position: relative;
 }
 
 header h1 {
@@ -57,6 +58,38 @@ header h1 {
     padding-bottom: 0.5rem;
     border-bottom: 2px solid var(--c-accent);
     display: inline-block;
+}
+
+#theme-toggle {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    width: 2.2rem;
+    height: 2.2rem;
+    border-radius: 50%;
+    border: 2px solid var(--c-light);
+    background: transparent;
+    color: var(--c-light);
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+#theme-toggle:focus-visible {
+    outline: 2px solid var(--c-accent);
+    outline-offset: 2px;
+}
+
+.hero {
+    background: linear-gradient(120deg, var(--c-primary), var(--c-featured));
+    color: var(--c-light);
+    padding: 4rem 1rem;
+    text-align: center;
+    margin-bottom: 2rem;
+}
+
+.hero-tagline {
+    font-size: 1.6rem;
+    letter-spacing: 0.03em;
 }
 
 nav ul {
@@ -422,9 +455,136 @@ footer {
         border-left-color: var(--c-accent);
     }
 
+    .hero {
+        background: linear-gradient(120deg, var(--c-dark), var(--c-vr-dark));
+        color: var(--c-light);
+    }
+
+    #theme-toggle {
+        border-color: var(--c-light);
+        color: var(--c-light);
+    }
+
     .ai-disclaimer strong {
         color: var(--c-accent);
     }
+}
+
+body.dark {
+    background: var(--c-dark);
+    color: var(--c-light);
+}
+
+body.dark header {
+    background: var(--c-dark);
+    color: var(--c-light);
+}
+
+body.dark header h1 {
+    border-bottom-color: var(--c-accent);
+}
+
+body.dark nav a {
+    color: var(--c-light);
+}
+
+body.dark section h2 {
+    color: var(--c-light);
+}
+
+body.dark #about h2 {
+    border-color: var(--c-about-dark);
+}
+
+body.dark #contact h2 {
+    border-color: var(--c-contact-dark);
+}
+
+body.dark .skill-group {
+    background: hsl(220, 10%, 25%);
+    border-top-color: var(--c-about-dark);
+}
+
+body.dark .skill-group h3 {
+    color: var(--c-about-dark);
+}
+
+body.dark .skill-group li {
+    color: var(--c-light);
+}
+
+body.dark .skill-group strong {
+    color: var(--c-about-dark);
+}
+
+body.dark .links-section {
+    background: hsl(220, 10%, 25%);
+    border-left-color: var(--c-about-dark);
+}
+
+body.dark .links-section a {
+    color: var(--c-about-dark);
+}
+
+body.dark .work-item {
+    background: hsl(220, 10%, 25%);
+    color: var(--c-light);
+}
+
+body.dark .more-works-section {
+    background: hsl(220, 10%, 25%);
+}
+
+body.dark .more-works-section a {
+    color: var(--c-accent);
+}
+
+body.dark footer {
+    color: var(--c-secondary);
+}
+
+body.dark .work-meta {
+    box-shadow: 0 2px 6px rgba(255,255,255,0.1);
+}
+
+body.dark .works-category:nth-of-type(1) .work-meta {
+    background: var(--c-featured-dark);
+    color: var(--c-dark);
+}
+
+body.dark .works-category:nth-of-type(2) .work-meta {
+    background: var(--c-vr-dark);
+    color: var(--c-dark);
+}
+
+body.dark .works-category:nth-of-type(3) .work-meta {
+    background: var(--c-display-dark);
+    color: var(--c-dark);
+}
+
+body.dark .works-category:nth-of-type(4) .work-meta {
+    background: var(--c-tool-dark);
+    color: var(--c-dark);
+}
+
+body.dark .hero {
+    background: linear-gradient(120deg, var(--c-dark), var(--c-vr-dark));
+    color: var(--c-light);
+}
+
+body.dark #theme-toggle {
+    border-color: var(--c-light);
+    color: var(--c-light);
+}
+
+body.dark .ai-disclaimer {
+    background: hsl(220, 10%, 25%);
+    color: var(--c-light);
+    border-left-color: var(--c-accent);
+}
+
+body.dark .ai-disclaimer strong {
+    color: var(--c-accent);
 }
 
 /* --- レスポンシブ --- */


### PR DESCRIPTION
## Summary
- add a hero section with tagline
- include a dark mode toggle button
- style hero, header and toggle
- provide dark mode styles via `body.dark`

## Testing
- `detect-public-source index.html style.css` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447c1e60e4832aba1e888aaece5bcd