### PR TITLE
Add reflex game mini app

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,15 @@
                 <p><a href="https://github.com/dmiyamo3/miyamo-notebook/blob/master/works.md" target="_blank" rel="noopener">🔗 全作品・展示履歴を見る</a></p>
             </div>
         </section>
+        <section id="reflex-game">
+            <h2>Reflex Game</h2>
+            <p class="game-desc">画面が緑になったらタップして反応速度を測りましょう。</p>
+            <div id="game-area">
+                <p id="game-info">スタートボタンを押してください</p>
+            </div>
+            <button id="start-btn" class="game-btn">スタート</button>
+            <p id="game-result" class="game-result"></p>
+        </section>
         <section id="contact">
             <h2>Contact</h2>
             <p>ご質問・ご相談は <a href="https://twitter.com/DMiyamo3" target="_blank" rel="noopener">Twitter</a> または <a href="https://github.com/dmiyamo3/dmiyamo3.github.io/issues" target="_blank" rel="noopener">GitHub Issues</a> からどうぞ。</p>
@@ -197,6 +206,49 @@
         const btn = document.getElementById('theme-toggle');
         btn.addEventListener('click', () => {
             document.body.classList.toggle('dark');
+        });
+
+        // Reflex Game Logic
+        const startBtn = document.getElementById('start-btn');
+        const gameArea = document.getElementById('game-area');
+        const gameInfo = document.getElementById('game-info');
+        const gameResult = document.getElementById('game-result');
+        let gameState = 'idle';
+        let startTime = 0;
+        let timerId;
+
+        function resetGame(msg) {
+            clearTimeout(timerId);
+            gameState = 'idle';
+            gameArea.classList.remove('ready');
+            startBtn.style.display = 'inline-block';
+            if (msg) gameInfo.textContent = msg;
+        }
+
+        function startGame() {
+            startBtn.style.display = 'none';
+            gameResult.textContent = '';
+            gameInfo.textContent = '赤色から緑色に変わったらタップ!';
+            gameState = 'waiting';
+            const delay = 2000 + Math.random() * 3000;
+            timerId = setTimeout(() => {
+                gameState = 'ready';
+                gameArea.classList.add('ready');
+                gameInfo.textContent = '今だ! タップ!';
+                startTime = performance.now();
+            }, delay);
+        }
+
+        startBtn.addEventListener('click', startGame);
+
+        gameArea.addEventListener('click', () => {
+            if (gameState === 'ready') {
+                const reaction = ((performance.now() - startTime) / 1000).toFixed(3);
+                gameResult.textContent = `反応速度: ${reaction} 秒`;
+                resetGame('もう一度プレイできます');
+            } else if (gameState === 'waiting') {
+                resetGame('早すぎます...');
+            }
         });
     </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -624,3 +624,48 @@ body.dark .ai-disclaimer strong {
 .ai-disclaimer strong {
     color: var(--c-accent);
 }
+
+/* ---- Reflex Game ---- */
+#reflex-game {
+    text-align: center;
+    margin: 3rem 0;
+}
+
+#game-area {
+    margin: 1.5rem auto;
+    width: 100%;
+    max-width: 300px;
+    height: 150px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: hsl(0, 70%, 55%);
+    border-radius: 8px;
+    color: #fff;
+    cursor: pointer;
+    user-select: none;
+    font-size: 1.1rem;
+}
+
+#game-area.ready {
+    background: hsl(140, 70%, 40%);
+}
+
+#start-btn {
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+.game-result {
+    font-size: 1.2rem;
+    margin-top: 1rem;
+}
+
+body.dark #game-area {
+    background: hsl(0, 70%, 45%);
+}
+
+body.dark #game-area.ready {
+    background: hsl(140, 70%, 35%);
+}


### PR DESCRIPTION
## Summary
- implement a Reflex Game section and start button
- show reaction time for each tap and reset correctly
- style the mini game and support dark mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684496e52bec832a830ec3fa8546eefe